### PR TITLE
Guard against case where drive is not set

### DIFF
--- a/epspCode.c
+++ b/epspCode.c
@@ -446,7 +446,7 @@ void sendHeaderBlock(int epsp_port) {
         cmdMsg[4] = driveParam.command;
         msg(LOG_DEBUG, "  sendHeaderBlock; FNC is %s\n", label[(int)driveParam.command]);
 	driveParam.returnCode = 0; /* setting default */
-        if (driveParam.drive) {
+        if (driveParam.drive > 0) {
             /* check for actually mounted image */
 	    int fd = driveInfo.drive_fd[getDriveId()];
 	    if (fd == -1) {

--- a/epspCode.c
+++ b/epspCode.c
@@ -446,14 +446,16 @@ void sendHeaderBlock(int epsp_port) {
         cmdMsg[4] = driveParam.command;
         msg(LOG_DEBUG, "  sendHeaderBlock; FNC is %s\n", label[(int)driveParam.command]);
 	driveParam.returnCode = 0; /* setting default */
-	/* check for actually mounted image */
-	int fd = driveInfo.drive_fd[getDriveId()];
-	if (fd == -1) {
+        if (driveParam.drive) {
+            /* check for actually mounted image */
+	    int fd = driveInfo.drive_fd[getDriveId()];
+	    if (fd == -1) {
 		msg(LOG_DEBUG, "  sendHeaderBlock; no image mounted on fd(%d). returning error\n", fd);
 		protocolHandler.composeSendTextBlock = composeSendReturnCodeTextBlock;
 		protocolHandler.getTextBlockSize = getEmptyTextBlockSize;
 		driveParam.returnCode = BDOS_RDERR;
-	}
+	    }
+        }
 	cmdMsg[5] = protocolHandler.getTextBlockSize();
         cmdMsg[6] = sumChars(cmdMsg, HEADER_BLK_SIZE -1);
         epspWrite(epsp_port, cmdMsg, HEADER_BLK_SIZE);


### PR DESCRIPTION
Thank you for all your work on PX-8.

This code has worked for me in linux for many years, but I discovered this trying to port to Windows yesterday.(the issue surfaced when comping with zig which had bounds checking on for debug)  

When handling the FDC_WRITEHST (79h) command driveParam.drive is not set(defaulting to 0) and then getDriveId returns -1 causing 
`int fd = driveInfo.drive_fd[getDriveId()];`
in sendHeaderBlock to index drive_fd[-1] and that's out of bounds.

The following is the output of case not working(dir d: on px-8):

```EPSPD version 2.4beta (2022-06-11)
 main; set debug level to 4
 main; Used devices:
       0: 
       1: 
       2: 
       3: /dev/ttyUSB0
       4: images/promprogs.d88
       5: 
       6: 
       7: 
       8: 
       9: 

EPSPD: Starting EPSP disk services on /dev/ttyUSB0
--000000------------------------------------------------------------------------
   epspRead; fd(3, /dev/ttyUSB0, [01])  04 
  waitForEOT; good: EOT received
 session; EOT received at start cycle, expecting address message
   epspRead; fd(3, /dev/ttyUSB0, [04])  31 31 22 05 
  recENQBlock; good: ENQ block size ok
  recENQBlock; good: PS received
  recENQBlock; DID is a D/E (31h)
  recENQBlock; SID is a PX-8 (22h)
  recENQBlock; ENQ present
 session; ENQ block ok, sending ACK, expecting command message
   epspWrite; fd(3, /dev/ttyUSB0): 06 
  sendACK; Sent ACK
   epspRead; fd(3, /dev/ttyUSB0, [07])  01 00 31 22 79 00 33 
  recHeaderBlock; good: Header block size ok
  recHeaderBlock; good: SOH received
  recHeaderBlock; good: FNT = 0
  recHeaderBlock; DID is D/E (31h)
  recHeaderBlock; SID is a PX-8 (22h)
  recHeaderBlock; good: checksum adds up to 0
  recHeaderBlockDataProccessing; Text block size is 00
  recHeaderBlockDataProccessing; FNC is FDC_WRITEHST (79h)
 session; Header block ok, sending ACK, expecting data message
   epspWrite; fd(3, /dev/ttyUSB0): 06 
  sendACK; Sent ACK
   epspRead; fd(3, /dev/ttyUSB0, [04])  02 00 03 FB 
  recTextBlock; good: Text block size ok
  recTextBlock; good: STX received at pos: 00
  recTextBlock; good: ETX received at pos: 02
  recTextBlock; good: checksum adds up to 0
Reset command.
 session; Text block ok, sending ACK, expecting EOT
   epspWrite; fd(3, /dev/ttyUSB0): 06 
  sendACK; Sent ACK
   epspRead; fd(3, /dev/ttyUSB0, [01])  04 
  waitForEOT; good: EOT received
 session; EOT received, to send mode
  sendHeaderBlock; DID is PX-8 (22h)
  sendHeaderBlock; SID is D/E (31h)
  sendHeaderBlock; FNC is FDC_WRITEHST (79h)
Illegal instruction
```